### PR TITLE
Update Dockerfile

### DIFF
--- a/docker/virtuoso/Dockerfile
+++ b/docker/virtuoso/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:trusty
+FROM ubuntu:kinetic
 
 ENV VIRT_HOME /opt/virtuoso-opensource
 
@@ -14,7 +14,7 @@ RUN apt-get -y update && \
   rm -rf /tmp/*
 
 WORKDIR /opt
-RUN git clone git://github.com/openlink/virtuoso-opensource.git virtuoso-opensource.src
+RUN git clone http://github.com/openlink/virtuoso-opensource.git virtuoso-opensource.src
 WORKDIR /opt/virtuoso-opensource.src
 RUN git checkout develop/7
 RUN ./autogen.sh && ./configure --prefix=$VIRT_HOME $VIRT_BUILD_OPTS && make && make install


### PR DESCRIPTION
Mark said, "The error seems to be a Docker error rather than from Virtuoso. I wonder if changing the base image to a newer version of Ubuntu will help. I think Trusty is now EOL which could mean apt is spitting out errors that aren’t making it to the console (and apt failing would be consistent with an i/o error)"

So we're changing the first line from Trusty to Kinetic Ubuntu

And I made that small change from git:// to http:// on ln 17